### PR TITLE
Fix micromenu missing quests-texture

### DIFF
--- a/modules/micromenu.lua
+++ b/modules/micromenu.lua
@@ -192,7 +192,7 @@ local microDefinitions = {
 	},
 
 	{ -- [9]
-		name = "Quest",
+		name = "Quests",
 		title = L["MicroQuest_Name"],
 		any = L["MicroQuest_Any"],
 		OnClick = function(self, btn_)


### PR DESCRIPTION
Fixes a typo that caused the micromenu's quest-texture not to load correctly.
 Closes #6