### PR TITLE
Update guild button to open new guild panel in communities

### DIFF
--- a/modules/micromenu.lua
+++ b/modules/micromenu.lua
@@ -181,7 +181,7 @@ local microDefinitions = {
 			else
 				--Those panels may not be loaded before we call them, so deal with that.
 				if IsInGuild() then
-					GuildFrame_LoadUI()
+					ToggleGuildFrame()
 					module:TogglePanel(GuildFrame)
 				else
 					LookingForGuildFrame_LoadUI()


### PR DESCRIPTION
Updates the micromenu's guild/friend's button to open the new guild-tab in communities-window when left clicked, instead of the old guild frame.
Closes #9