### PR TITLE
Micromenu: Fixes error related to invalid index of 'button'

### DIFF
--- a/modules/micromenu.lua
+++ b/modules/micromenu.lua
@@ -219,7 +219,7 @@ local microDefinitions = {
 			module:TogglePanel(PlayerTalentFrame)
 		end,
 	},
-	
+
 	{ -- [12]
 		name = "Spellbook",
 		title = L["MicroSpell_Name"],
@@ -325,7 +325,7 @@ MicroButtonClickerMixin.clickerBackdrop = {
 function module:NewMicroButton(buttonData)
 	local r, g, b, a_ = module:RGBA("Micromenu")
 	local name = buttonData.name
-	
+
 	local button = CreateFrame("Frame", "LUIMicromenu_"..name, UIParent)
 	button:SetSize(TEXTURE_SIZE_WIDTH, TEXTURE_SIZE_HEIGHT)
 	Mixin(button, buttonData)
@@ -447,7 +447,9 @@ function module:Refresh()
 	local r, g, b, a_ = module:RGBA("Micromenu")
 	for i = 1, #microList do
 		local button = microStorage[microList[i]]
-		button.tex:SetVertexColor(r, g, b)
+		if button then
+			button.tex:SetVertexColor(r, g, b)
+		end
 	end
 end
 


### PR DESCRIPTION
Error was

``LUI4\modules\micromenu.lua:451: attempt to index local 'button' (a nil value)
LUI4\modules\micromenu.lua:451: in function `?'
LUI4\api\options-Options.lua:124: in function <LUI4\api\options.lua:118>
LUI4\api\options-Options.lua:237: in function <LUI4\api\options.lua:230>``

Just checks button's existence